### PR TITLE
Add optional parameter '--first <elevation>' to set min elevation level

### DIFF
--- a/Brejc.DemLibrary/IIsopletingAlgorithm.cs
+++ b/Brejc.DemLibrary/IIsopletingAlgorithm.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-//using Brejc.Visualization;
-
 namespace Brejc.DemLibrary
 {
     public delegate void NewIsohypseCallback (Isohypse isohypse);
@@ -25,9 +20,10 @@ namespace Brejc.DemLibrary
         /// </summary>
         /// <param name="dem">The digital elevation model.</param>
         /// <param name="elevationStep">The step (in meters) to use when calculating isohypses.</param>
+        /// <param name="setMinElevation">The first elevation (in meters) to use when calculating isohypses (if not null).</param>
         /// <returns>A collection of isohypses stored in the <see cref="IsohypseCollection"/> object.</returns>
-        IsohypseCollection Isoplete (IRasterDigitalElevationModel dem, double elevationStep);
+        IsohypseCollection Isoplete (IRasterDigitalElevationModel dem, double elevationStep, double? setMinElevation);
 
-        void Isoplete (IRasterDigitalElevationModel dem, double elevationStep, NewIsohypseCallback callback);
+        void Isoplete (IRasterDigitalElevationModel dem, double elevationStep, double? setMinElevation, NewIsohypseCallback callback);
     }
 }

--- a/Brejc.DemLibrary/Igor4IsopletingAlgorithm.cs
+++ b/Brejc.DemLibrary/Igor4IsopletingAlgorithm.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 //using Brejc.Visualization;
 using System.Diagnostics.CodeAnalysis;
 using Brejc.Geometry;
@@ -29,11 +28,19 @@ namespace Brejc.DemLibrary
         //}
 
         [SuppressMessage ("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional", MessageId = "Body")]
-        public void Isoplete (IRasterDigitalElevationModel dem, double elevationStep, NewIsohypseCallback callback)
+        public void Isoplete (IRasterDigitalElevationModel dem, double elevationStep, double? setMinElevation, NewIsohypseCallback callback)
         {
             DigitalElevationModelStatistics statistics = dem.CalculateStatistics ();
 
-            double minElevation = Math.Floor (statistics.MinElevation / elevationStep) * elevationStep;
+            double minElevation;
+            if (setMinElevation.HasValue)
+            {
+                minElevation = setMinElevation.Value;
+            }
+            else
+            {
+                minElevation = Math.Floor(statistics.MinElevation / elevationStep) * elevationStep;
+            }
             double maxElevation = Math.Floor (statistics.MaxElevation / elevationStep) * elevationStep;
 
             //if (visualizer != null)
@@ -208,11 +215,11 @@ namespace Brejc.DemLibrary
             }
         }
 
-        public IsohypseCollection Isoplete (IRasterDigitalElevationModel dem, double elevationStep)
+        public IsohypseCollection Isoplete (IRasterDigitalElevationModel dem, double elevationStep, double? setMinElevation)
         {
             IsohypseCollection isoColl = new IsohypseCollection ();
 
-            Isoplete (dem, elevationStep, delegate (Isohypse isohypse)
+            Isoplete (dem, elevationStep, setMinElevation, delegate (Isohypse isohypse)
             {
                 isoColl.AddIsohypse (isohypse);
             });

--- a/Srtm2Osm/ConsoleApp.cs
+++ b/Srtm2Osm/ConsoleApp.cs
@@ -52,6 +52,7 @@ namespace Srtm2Osm
             Console.Out.WriteLine ("-i: forces the regeneration of SRTM index file (default: no)");
             Console.Out.WriteLine ("-feet: uses feet units for elevation instead of meters");
             Console.Out.WriteLine ("-step <elevation>: elevation step between contours (default: 20 units)");
+            Console.Out.WriteLine ("-first <elevation>: do not create contour lines below this level");
             Console.Out.WriteLine ("-cat <major> <medium>: adds contour category tag to OSM ways");
             Console.Out.WriteLine ("       example: -cat 400 100 will mark:");
             Console.Out.WriteLine ("           contours 400, 800, 1200 etc as contour_ext=elevation_major");

--- a/Srtm2Osm/Srtm2Osm.csproj
+++ b/Srtm2Osm/Srtm2Osm.csproj
@@ -103,7 +103,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="OsmUtils.snk" />
   </ItemGroup>
   <ItemGroup>

--- a/Srtm2Osm/Srtm2OsmCommand.cs
+++ b/Srtm2Osm/Srtm2OsmCommand.cs
@@ -1,16 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Brejc.Common.Console;
 using Brejc.DemLibrary;
-using OsmUtils.Framework;
-using OsmUtils.OsmSchema;
 using System.IO;
-using OsmUtils.OsmClient;
 using System.Xml;
 using System.Web;
 using System.Collections.Specialized;
-using System.Xml.Serialization;
 using Brejc.Geometry;
 using System.Text.RegularExpressions;
 using System.Globalization;
@@ -33,6 +28,7 @@ namespace Srtm2Osm
         LargeAreaMode,
         CorrectionXY,
         SrtmSource,
+        SetMinElevation,
         MaxWayNodes,
         FirstNodeId,
         FirstWayId,
@@ -165,7 +161,7 @@ namespace Srtm2Osm
 
                 try
                 {
-                    alg.Isoplete (dem, elevationStepInUnits, delegate(Isohypse isohypse)
+                    alg.Isoplete (dem, elevationStepInUnits, setMinElevation, delegate(Isohypse isohypse)
                     {
                         output.ProcessIsohypse (isohypse, delegate() { return GetNextId (nodeCounter, true); },
                             delegate() { return GetNextId (wayCounter, false); });
@@ -214,6 +210,7 @@ namespace Srtm2Osm
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.LargeAreaMode, "large", 0));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.CorrectionXY, "corrxy", 2));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSource, "source", 1));
+            options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SetMinElevation, "first", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.MaxWayNodes, "maxwaynodes", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.FirstNodeId, "firstnodeid", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.FirstWayId, "firstwayid", 1));
@@ -395,6 +392,10 @@ namespace Srtm2Osm
                         if (elevationStep <= 0)
                             throw new ArgumentException ("Elevation step must be a positive integer value.");
 
+                        continue;
+
+                    case Srtm2OsmCommandOption.SetMinElevation:
+                        setMinElevation = double.Parse(option.Parameters[0], CultureInfo.InvariantCulture);
                         continue;
 
                     case Srtm2OsmCommandOption.Categories:
@@ -605,6 +606,7 @@ namespace Srtm2Osm
         private IContourMarker contourMarker = new DefaultContourMarker();
         private bool largeAreaMode;
         private Uri srtmSource;
+        private double ? setMinElevation = null;
         private int maxWayNodes = 5000;
         private long firstNodeId = long.MaxValue - 10;
         private long firstWayId = long.MaxValue - 10;


### PR DESCRIPTION
- use this to avoid contour lines for elevation 0 and below (useful when there is no land below sea level and when map already has coast lines)
- remove non existing file app.config in Srtm2Osm.csproj to avoid build errors