### PR TITLE
Enable flat sources

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Reflection;
 [assembly: AssemblyConfigurationAttribute("release")]
 [assembly: AssemblyCompanyAttribute("Igor Brejc and others")]
 [assembly: AssemblyProductAttribute("Srtm2Osm")]
-[assembly: AssemblyCopyrightAttribute("Copyright (C) 2007-2023 Igor Brejc and others")]
+[assembly: AssemblyCopyrightAttribute("Copyright (C) 2007-2024 Igor Brejc and others")]
 [assembly: AssemblyTrademarkAttribute("")]
 [assembly: AssemblyCultureAttribute("")]
 [assembly: AssemblyFileVersionAttribute("1.16.5.0")]

--- a/Srtm2Osm/ConsoleApp.cs
+++ b/Srtm2Osm/ConsoleApp.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Brejc.Common.Console;
 
 namespace Srtm2Osm
 {
-    public class ConsoleApp : Brejc.Common.Console.ConsoleApplicationBase
+    public class ConsoleApp : ConsoleApplicationBase
     {
         public ConsoleApp (string[] args) : base (args) {}
 
@@ -63,6 +62,8 @@ namespace Srtm2Osm
             Console.Out.WriteLine ("-corrxy <corrLng> <corrLat>: correction values to shift contours");
             Console.Out.WriteLine ("-source <url>: base URL used for download");
             Console.Out.WriteLine ("       (default 'http://firmware.ardupilot.org/SRTM/')");
+            Console.Out.WriteLine ("-sourceflat <url>: URL used for download without region structure");
+            Console.Out.WriteLine ("-sourceextension <ext>: extension of the source files (default: .hgt.zip)");
             Console.Out.WriteLine ("-maxwaynodes <count>: specifies the maximum number of nodes in a single way");
             Console.Out.WriteLine ("-firstnodeid <id>: specifies the first ID of a node (default: 2^63-11)");
             Console.Out.WriteLine ("-firstwayid <id>: specifies the first ID of a way (default: 2^63-11)");

--- a/Srtm2Osm/ReleaseNotes.txt
+++ b/Srtm2Osm/ReleaseNotes.txt
@@ -3,6 +3,17 @@ Srtm2Osm tool by Igor Brejc and others
 VERSION HISTORY
 ---------------
 
+1.xx
+----
+- Add option to support unstructured sources (-sourceflat)
+- Add option to use specific source file extension (-sourceextension, default: .hgt.zip)
+- Redesign index file to support flat sources and avoid serialization of SrtmIndex class
+  (insecure BinaryFormatter will break update to .net 8)
+- Suppress error for index recreation with parameter -i without bounds specified
+- Cleanup Code of Srtm2OsmCommand
+  - extract methods to set source and bounds
+  - adjust data types (Double => double, Int16 => short)
+
 1.16
 ----
 - Changed defaults for node & way IDs, because downstream software uses the old defaults for state handling.

--- a/Srtm2Osm/Srtm2OsmCommand.cs
+++ b/Srtm2Osm/Srtm2OsmCommand.cs
@@ -222,11 +222,10 @@ namespace Srtm2Osm
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.Feet, "feet", 0));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.LargeAreaMode, "large", 0));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.CorrectionXY, "corrxy", 2));
-            options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSource, "source", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SetMinElevation, "first", 1));
-            options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSourceFlat, "flatsource", 1));
-            options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSourceExtension, "sourceextension", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSource, "source", 1));
+            options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSourceFlat, "sourceflat", 1));
+            options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSourceExtension, "sourceextension", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.MaxWayNodes, "maxwaynodes", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.FirstNodeId, "firstnodeid", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.FirstWayId, "firstwayid", 1));

--- a/Srtm2Osm/Srtm2OsmCommand.cs
+++ b/Srtm2Osm/Srtm2OsmCommand.cs
@@ -64,6 +64,7 @@ namespace Srtm2Osm
             activityLogger.LogFormat(ActivityLogLevel.Verbose, "Set Source in index to {0}", srtmSource);
             SrtmIndex.SrtmSource = srtmSource;
             SrtmIndex.SrtmSourceFlat = srtmSourceFlat;
+            SrtmIndex.SrtmSourceExtension = srtmSourceExtension;
             var forceIndexGeneration = false;
 
             try
@@ -269,11 +270,11 @@ namespace Srtm2Osm
                         continue;
 
                     case Srtm2OsmCommandOption.OutputFile:
-                        outputOsmFile = option.Parameters[0];
+                        outputOsmFile = option.Parameters [0];
                         continue;
 
                     case Srtm2OsmCommandOption.MergeFile:
-                        osmMergeFile = option.Parameters[0];
+                        osmMergeFile = option.Parameters [0];
                         continue;
 
                     case Srtm2OsmCommandOption.SrtmCachePath:
@@ -288,7 +289,7 @@ namespace Srtm2Osm
                         elevationStep = int.Parse (option.Parameters[0], CultureInfo.InvariantCulture);
 
                         if (elevationStep <= 0)
-                            throw new ArgumentException("Elevation step must be a positive integer value.");
+                            throw new ArgumentException ("Elevation step must be a positive integer value.");
 
                         continue;
 
@@ -296,7 +297,7 @@ namespace Srtm2Osm
                         majorFactor = double.Parse (option.Parameters[0], CultureInfo.InvariantCulture);
                         mediumFactor = double.Parse (option.Parameters[1], CultureInfo.InvariantCulture);
 
-                        contourMarker = new MkgmapContourMarker(majorFactor, mediumFactor);
+                        contourMarker = new MkgmapContourMarker (majorFactor, mediumFactor);
                         continue;
 
                     case Srtm2OsmCommandOption.Feet:
@@ -340,7 +341,7 @@ namespace Srtm2Osm
                         splitWidth = double.Parse(option.Parameters[1], CultureInfo.InvariantCulture);
 
                         if (splitWidth <= 0 || splitHeight <= 0)
-                            throw new ArgumentException("The split width or height may not be smaller than zero.");
+                            throw new ArgumentException ("The split width or height may not be smaller than zero.");
 
                         continue;
                 }

--- a/Srtm2Osm/Srtm2OsmCommand.cs
+++ b/Srtm2Osm/Srtm2OsmCommand.cs
@@ -5,7 +5,6 @@ using Brejc.DemLibrary;
 using System.IO;
 using System.Xml;
 using System.Web;
-using System.Collections.Specialized;
 using Brejc.Geometry;
 using System.Text.RegularExpressions;
 using System.Globalization;
@@ -28,6 +27,8 @@ namespace Srtm2Osm
         LargeAreaMode,
         CorrectionXY,
         SrtmSource,
+        SrtmSourceFlat,
+        SrtmSourceExtension,
         SetMinElevation,
         MaxWayNodes,
         FirstNodeId,
@@ -43,8 +44,10 @@ namespace Srtm2Osm
         [System.Diagnostics.CodeAnalysis.SuppressMessage ("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public void Execute ()
         {
-            ConsoleActivityLogger activityLogger = new ConsoleActivityLogger();
-            activityLogger.LogLevel = ActivityLogLevel.Verbose;
+            ConsoleActivityLogger activityLogger = new ConsoleActivityLogger
+            {
+                LogLevel = ActivityLogLevel.Verbose
+            };
 
             // Use all available encryption protocols supported in the .NET Framework 4.0.
             // TLS versions > 1.0 are supported and available via the extensions.
@@ -56,45 +59,54 @@ namespace Srtm2Osm
             Directory.CreateDirectory (srtmDir);
 
             string srtmIndexFilename = Path.Combine (srtmDir, "SrtmIndex.dat");
-            SrtmIndex srtmIndex = null;
+            SrtmIndex srtmIndex = new SrtmIndex();
+            srtmIndex.ActivityLogger = activityLogger;
+            activityLogger.LogFormat(ActivityLogLevel.Verbose, "Set Source in index to {0}", srtmSource);
             SrtmIndex.SrtmSource = srtmSource;
+            SrtmIndex.SrtmSourceFlat = srtmSourceFlat;
+            var forceIndexGeneration = false;
 
             try
             {
-                srtmIndex = SrtmIndex.Load (srtmIndexFilename);
+                if (!srtmIndex.Load (srtmIndexFilename))
+                {
+                    forceIndexGeneration = true;
+                }
             }
             catch (Exception)
             {
                 // in case of exception, regenerate the index
-                generateIndex = true;
+                forceIndexGeneration = true;
             }
 
-            if (generateIndex)
+            if (generateIndex | forceIndexGeneration)
             {
-                srtmIndex = new SrtmIndex ();
-                srtmIndex.ActivityLogger = activityLogger;
                 srtmIndex.Generate ();
                 srtmIndex.Save (srtmIndexFilename);
-
-                srtmIndex = SrtmIndex.Load (srtmIndexFilename);
             }
 
-            Srtm3Storage.SrtmSource = srtmSource;
-            Srtm3Storage storage = new Srtm3Storage(Path.Combine(srtmDir, "SrtmCache"), srtmIndex);
-            storage.ActivityLogger = activityLogger;
+            var srtmCacheFolder = Path.Combine(srtmDir, "SrtmCache");
+            IDemLoader storage = new Srtm3Storage(srtmCacheFolder, srtmIndex)
+            {
+                ActivityLogger = activityLogger,
+                Source = srtmSource,
+                SourceExtension = srtmSourceExtension
+            };
 
-            IIsopletingAlgorithm alg = new Igor4IsopletingAlgorithm ();
-            alg.ActivityLogger = activityLogger;
+            IIsopletingAlgorithm alg = new Igor4IsopletingAlgorithm
+            {
+                ActivityLogger = activityLogger
+            };
 
             double elevationStepInUnits = elevationStep * elevationUnits;
             contourMarker.Configure (elevationUnits);
 
             // Default: Start with highest possible ID and count down. That should give maximum space
             // between contour data and real OSM data.
-            IdCounter nodeCounter = new IdCounter (incrementId, firstNodeId);
-            IdCounter wayCounter = new IdCounter (incrementId, firstWayId);
+            var nodeCounter = new IdCounter (incrementId, firstNodeId);
+            var wayCounter = new IdCounter (incrementId, firstWayId);
 
-            OutputSettings settings = new OutputSettings ();
+            var settings = new OutputSettings ();
             settings.ContourMarker = contourMarker;
             settings.LongitudeCorrection = corrX;
             settings.LatitudeCorrection = corrY;
@@ -137,9 +149,9 @@ namespace Srtm2Osm
                 Bounds2 corrBounds = new Bounds2 (bound.MinX - corrX, bound.MinY - corrY,
                     bound.MaxX - corrX, bound.MaxY - corrY);
 
-                activityLogger.LogFormat (ActivityLogLevel.Normal, "Calculating contour data for bound {0}...", corrBounds);
+                activityLogger.LogFormat (ActivityLogLevel.Normal, "Calculating contour data for bound {0} ...", corrBounds);
 
-                IRasterDigitalElevationModel dem = (IRasterDigitalElevationModel) storage.LoadDemForArea (corrBounds);
+                var dem = (IRasterDigitalElevationModel) storage.LoadDemForArea (corrBounds);
 
                 // clear up some memory used in storage object
                 if (this.bounds.Count == 1)
@@ -150,13 +162,13 @@ namespace Srtm2Osm
 
                 DigitalElevationModelStatistics statistics = dem.CalculateStatistics ();
 
-                activityLogger.Log (ActivityLogLevel.Normal, String.Format (CultureInfo.InvariantCulture,
+                activityLogger.Log (ActivityLogLevel.Normal, string.Format (CultureInfo.InvariantCulture,
                     "DEM data points count: {0}", dem.DataPointsCount));
-                activityLogger.Log (ActivityLogLevel.Normal, String.Format (CultureInfo.InvariantCulture,
+                activityLogger.Log (ActivityLogLevel.Normal, string.Format (CultureInfo.InvariantCulture,
                     "DEM minimum elevation: {0}", statistics.MinElevation));
-                activityLogger.Log (ActivityLogLevel.Normal, String.Format (CultureInfo.InvariantCulture,
+                activityLogger.Log (ActivityLogLevel.Normal, string.Format (CultureInfo.InvariantCulture,
                     "DEM maximum elevation: {0}", statistics.MaxElevation));
-                activityLogger.Log (ActivityLogLevel.Normal, String.Format (CultureInfo.InvariantCulture,
+                activityLogger.Log (ActivityLogLevel.Normal, string.Format (CultureInfo.InvariantCulture,
                     "DEM has missing points: {0}", statistics.HasMissingPoints));
 
                 try
@@ -183,7 +195,7 @@ namespace Srtm2Osm
                     activityLogger.Log(ActivityLogLevel.Warning, "No contour line found. Try to increase the overall area.");
             }
 
-            if (!largeAreaMode)
+            if (output.HasData && !largeAreaMode)
                 activityLogger.Log (ActivityLogLevel.Normal, "Saving contour data to file...");
 
             output.End ();
@@ -211,6 +223,9 @@ namespace Srtm2Osm
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.CorrectionXY, "corrxy", 2));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSource, "source", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SetMinElevation, "first", 1));
+            options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSourceFlat, "flatsource", 1));
+            options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSourceExtension, "sourceextension", 1));
+            options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SrtmSource, "source", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.MaxWayNodes, "maxwaynodes", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.FirstNodeId, "firstnodeid", 1));
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.FirstWayId, "firstwayid", 1));
@@ -218,164 +233,47 @@ namespace Srtm2Osm
             options.AddOption (new ConsoleApplicationOption ((int)Srtm2OsmCommandOption.SplitBounds, "splitbounds", 2));
 
             startFrom = options.ParseArgs (args, startFrom);
-            CultureInfo invariantCulture = CultureInfo.InvariantCulture;
 
-            foreach (ConsoleApplicationOption option in options.UsedOptions)
+            foreach (var option in options.UsedOptions)
             {
                 switch ((Srtm2OsmCommandOption)option.OptionId)
                 {
                     case Srtm2OsmCommandOption.CorrectionXY:
-                        {
-                            corrX = Double.Parse (option.Parameters[0], invariantCulture);
-                            corrY = Double.Parse (option.Parameters[1], invariantCulture);
-                            continue;
-                        }
+                        corrX = double.Parse(option.Parameters[0], CultureInfo.InvariantCulture);
+                        corrY = double.Parse(option.Parameters[1], CultureInfo.InvariantCulture);
+                        continue;
 
                     case Srtm2OsmCommandOption.SrtmSource:
-                        {
-                            Uri uri;
+                        SetSource(option.Parameters[0]);
+                        continue;
 
-                            try
-                            {
-                                string url = option.Parameters[0];
+                    case Srtm2OsmCommandOption.SrtmSourceFlat:
+                        srtmSourceFlat = true;
+                        SetSource(option.Parameters[0]);
+                        continue;
 
-                                // The URI has to end with a slash
-                                if (!url.EndsWith("/", StringComparison.Ordinal))
-                                    url += "/";
-
-                                uri = new Uri (url);
-                            }
-                            catch (UriFormatException)
-                            {
-                                throw new ArgumentException ("The source URL is not valid.");
-                            }
-
-                            // Check if the prefix is supported. Unfortunately I couldn't find a method to check which
-                            // prefixes are registered without calling WebRequest.Create(), which I didn't want here.
-                            if (uri.Scheme != "http" && uri.Scheme != "https" && uri.Scheme != "ftp" && uri.Scheme != "file")
-                            {
-                                string error = String.Format(invariantCulture, "The source's scheme ('{0}') is not supported.", uri.Scheme);
-                                throw new ArgumentException (error);
-                            }
-
-                            srtmSource = uri;
-
-                            continue;
-                        }
+                    case Srtm2OsmCommandOption.SrtmSourceExtension:
+                        srtmSourceExtension = option.Parameters[0];
+                        continue;
 
                     case Srtm2OsmCommandOption.Bounds1:
-                        {
-                            double minLat = Double.Parse (option.Parameters[0], invariantCulture);
-                            double minLng = Double.Parse (option.Parameters[1], invariantCulture);
-                            double maxLat = Double.Parse (option.Parameters[2], invariantCulture);
-                            double maxLng = Double.Parse (option.Parameters[3], invariantCulture);
-
-                            if (minLat == maxLat)
-                                throw new ArgumentException ("Minimum and maximum latitude may not have the same value.");
-
-                            if (minLng == maxLng)
-                                throw new ArgumentException ("Minimum and maximum longitude may not have the same value.");
-
-                            if (minLat > maxLat)
-                            {
-                                double sw = minLat;
-                                minLat = maxLat;
-                                maxLat = sw;
-                            }
-
-                            if (minLng > maxLng)
-                            {
-                                double sw = minLng;
-                                minLng = maxLng;
-                                maxLng = sw;
-                            }
-
-                            EnsureValidCoords (minLat, maxLat, minLng, maxLng);
-
-                            this.bounds.Add (new Bounds2 (minLng, minLat, maxLng, maxLat));
-                            continue;
-                        }
+                        SetBounds1 (option.Parameters[0], option.Parameters[1], option.Parameters[2], option.Parameters[3]);
+                        continue;
 
                     case Srtm2OsmCommandOption.Bounds2:
-                        {
-                            double lat = Double.Parse (option.Parameters[0], invariantCulture);
-                            double lng = Double.Parse (option.Parameters[1], invariantCulture);
-                            double boxSizeInKilometers = Double.Parse (option.Parameters[2], invariantCulture);
-
-                            this.bounds.Add (CalculateBounds (lat, lng, boxSizeInKilometers));
-                            continue;
-                        }
+                        SetBounds2 (option.Parameters[0], option.Parameters[1], option.Parameters[2]);
+                        continue;
 
                     case Srtm2OsmCommandOption.Bounds3:
-                        {
-                            Uri slippyMapUrl = new Uri (option.Parameters[0]);
-                            double lat = 0;
-                            double lng = 0;
-                            int zoomLevel = 0;
-
-                            if (slippyMapUrl.Fragment != String.Empty)
-                            {
-                                // map=18/50.07499/10.21574
-                                string pattern = @"map=(\d+)/([-\.\d]+)/([-\.\d]+)";
-                                Match match = Regex.Match(slippyMapUrl.Fragment, pattern);
-
-                                if (match.Success)
-                                {
-                                    try
-                                    {
-                                        zoomLevel = Int32.Parse(match.Groups[1].Value, invariantCulture); 
-                                        lat = Double.Parse(match.Groups[2].Value, invariantCulture);
-                                        lng = Double.Parse(match.Groups[3].Value, invariantCulture);
-                                    }
-                                    catch (FormatException fex)
-                                    {
-                                        throw new ArgumentException("Invalid slippymap URL.", fex);
-                                    }
-
-                                    this.bounds.Add (CalculateBounds (lat, lng, zoomLevel));
-                                }
-                                else
-                                    throw new ArgumentException("Invalid slippymap URL.");
-                            }
-                            else if (slippyMapUrl.Query != String.Empty)
-                            {
-                                string queryPart = slippyMapUrl.Query;
-                                NameValueCollection queryParameters = HttpUtility.ParseQueryString(queryPart);
-
-                                if (queryParameters["lat"] != null
-                                    && queryParameters["lon"] != null
-                                    && queryParameters["zoom"] != null)
-                                {
-                                    try
-                                    {
-                                        lat = Double.Parse(queryParameters["lat"], invariantCulture);
-                                        lng = Double.Parse(queryParameters["lon"], invariantCulture);
-                                        zoomLevel = Int32.Parse(queryParameters["zoom"], invariantCulture);
-                                    }
-                                    catch (FormatException fex)
-                                    {
-                                        throw new ArgumentException("Invalid slippymap URL.", fex);
-                                    }
-
-                                    this.bounds.Add (CalculateBounds (lat, lng, zoomLevel));
-                                }
-                                else if (queryParameters["bbox"] != null)
-                                    this.bounds.Add (CalculateBounds (queryParameters["bbox"]));
-                                else
-                                    throw new ArgumentException("Invalid slippymap URL.");
-                            }
-                            else
-                                throw new ArgumentException("Invalid slippymap URL.");
-
-                            continue;
-                        }
+                        SetBounds3 (option.Parameters[0], option.Parameters[1], option.Parameters[2], option.Parameters[3]);
+                        continue;
 
                     case Srtm2OsmCommandOption.OutputFile:
-                        outputOsmFile = option.Parameters [0];
+                        outputOsmFile = option.Parameters[0];
                         continue;
 
                     case Srtm2OsmCommandOption.MergeFile:
-                        osmMergeFile = option.Parameters [0];
+                        osmMergeFile = option.Parameters[0];
                         continue;
 
                     case Srtm2OsmCommandOption.SrtmCachePath:
@@ -387,23 +285,18 @@ namespace Srtm2Osm
                         continue;
 
                     case Srtm2OsmCommandOption.ElevationStep:
-                        elevationStep = int.Parse (option.Parameters [0], invariantCulture);
+                        elevationStep = int.Parse (option.Parameters[0], CultureInfo.InvariantCulture);
 
                         if (elevationStep <= 0)
-                            throw new ArgumentException ("Elevation step must be a positive integer value.");
+                            throw new ArgumentException("Elevation step must be a positive integer value.");
 
-                        continue;
-
-                    case Srtm2OsmCommandOption.SetMinElevation:
-                        setMinElevation = double.Parse(option.Parameters[0], CultureInfo.InvariantCulture);
                         continue;
 
                     case Srtm2OsmCommandOption.Categories:
-                        majorFactor = double.Parse (option.Parameters[0], invariantCulture);
-                        mediumFactor = double.Parse (option.Parameters[1], invariantCulture);
+                        majorFactor = double.Parse (option.Parameters[0], CultureInfo.InvariantCulture);
+                        mediumFactor = double.Parse (option.Parameters[1], CultureInfo.InvariantCulture);
 
-                        contourMarker = new MkgmapContourMarker (majorFactor, mediumFactor);
-
+                        contourMarker = new MkgmapContourMarker(majorFactor, mediumFactor);
                         continue;
 
                     case Srtm2OsmCommandOption.Feet:
@@ -415,7 +308,7 @@ namespace Srtm2Osm
                         continue;
 
                     case Srtm2OsmCommandOption.MaxWayNodes:
-                        maxWayNodes = Int32.Parse (option.Parameters[0], invariantCulture);
+                        maxWayNodes = short.Parse (option.Parameters[0], CultureInfo.InvariantCulture);
 
                         if (maxWayNodes < 2)
                             throw new ArgumentException ("The minimum number of nodes in a single way is 2.");
@@ -423,7 +316,7 @@ namespace Srtm2Osm
                         continue;
 
                     case Srtm2OsmCommandOption.FirstNodeId:
-                        firstNodeId = long.Parse(option.Parameters[0], invariantCulture);
+                        firstNodeId = long.Parse (option.Parameters[0], CultureInfo.InvariantCulture);
 
                         if (firstNodeId <= 0)
                             throw new ArgumentException ("A negative or zero node ID is not supported.");
@@ -431,7 +324,7 @@ namespace Srtm2Osm
                         continue;
 
                     case Srtm2OsmCommandOption.FirstWayId:
-                        firstWayId = long.Parse(option.Parameters[0], invariantCulture);
+                        firstWayId = long.Parse (option.Parameters[0], CultureInfo.InvariantCulture);
 
                         if (firstWayId <= 0)
                             throw new ArgumentException ("A negative or zero way ID is not supported.");
@@ -443,11 +336,11 @@ namespace Srtm2Osm
                         continue;
 
                     case Srtm2OsmCommandOption.SplitBounds:
-                        splitHeight = Double.Parse (option.Parameters[0], invariantCulture);
-                        splitWidth = Double.Parse (option.Parameters[1], invariantCulture);
+                        splitHeight = double.Parse(option.Parameters[0], CultureInfo.InvariantCulture);
+                        splitWidth = double.Parse(option.Parameters[1], CultureInfo.InvariantCulture);
 
                         if (splitWidth <= 0 || splitHeight <= 0)
-                            throw new ArgumentException ("The split width or height may not be smaller than zero.");
+                            throw new ArgumentException("The split width or height may not be smaller than zero.");
 
                         continue;
                 }
@@ -455,10 +348,16 @@ namespace Srtm2Osm
 
             // Check if bounds were specified
             if (bounds.Count == 0 && osmMergeFile != null)
-                this.bounds = RetrieveBoundsFromFile (osmMergeFile);
+                bounds = RetrieveBoundsFromFile (osmMergeFile);
 
             if (bounds.Count == 0)
-                throw new ArgumentException ("No bounds specified.");
+            {
+                // Allow recreation of index without definition of bounds
+                if (!generateIndex)
+                {
+                    throw new ArgumentException ("No bounds specified.");
+                }
+            }
 
             // Check if both first*id's are set when the user wants to increment the IDs
             if (incrementId && (firstNodeId == long.MaxValue || firstWayId == long.MaxValue))
@@ -467,16 +366,152 @@ namespace Srtm2Osm
             return startFrom;
         }
 
+        private void SetSource(string url)
+        {
+            Uri uri;
+
+            try
+            {
+                // The URI has to end with a slash
+                if (!url.EndsWith("/", StringComparison.Ordinal))
+                    url += "/";
+
+                uri = new Uri(url);
+            }
+            catch (UriFormatException)
+            {
+                throw new ArgumentException ("The source URL is not valid.");
+            }
+
+            // Check if the prefix is supported. Unfortunately I couldn't find a method to check which
+            // prefixes are registered without calling WebRequest.Create(), which I didn't want here.
+            if (uri.Scheme != "http" && uri.Scheme != "https" && uri.Scheme != "ftp" && uri.Scheme != "file")
+            {
+                string error = string.Format (CultureInfo.InvariantCulture, "The source's scheme ('{0}') is not supported.", uri.Scheme);
+                throw new ArgumentException(error);
+            }
+
+            srtmSource = uri;
+        }
+
+        private void SetBounds1 (string minLatParam, string minLngParam, string maxLatParam, string maxLngParam)
+        {
+            double minLat = double.Parse (minLatParam, CultureInfo.InvariantCulture);
+            double minLng = double.Parse (minLngParam, CultureInfo.InvariantCulture);
+            double maxLat = double.Parse (maxLatParam, CultureInfo.InvariantCulture);
+            double maxLng = double.Parse (maxLngParam, CultureInfo.InvariantCulture);
+
+            if (minLat == maxLat)
+                throw new ArgumentException ("Minimum and maximum latitude may not have the same value.");
+
+            if (minLng == maxLng)
+                throw new ArgumentException ("Minimum and maximum longitude may not have the same value.");
+
+            if (minLat > maxLat)
+            {
+                var sw = minLat;
+                minLat = maxLat;
+                maxLat = sw;
+            }
+
+            if (minLng > maxLng)
+            {
+                var sw = minLng;
+                minLng = maxLng;
+                maxLng = sw;
+            }
+
+            EnsureValidCoords (minLat, maxLat, minLng, maxLng);
+
+            bounds.Add (new Bounds2(minLng, minLat, maxLng, maxLat));
+        }
+
+        private void SetBounds2 (string latParam, string lngParam, string boxSize)
+        {
+            var lat = double.Parse (latParam, CultureInfo.InvariantCulture);
+            var lng = double.Parse (lngParam, CultureInfo.InvariantCulture);
+            var boxSizeInKilometers = double.Parse(boxSize, CultureInfo.InvariantCulture);
+
+            bounds.Add (CalculateBounds(lat, lng, boxSizeInKilometers));
+        }
+
+        private void SetBounds3 (string url, string zoomLevelParam, string latParam, string lngParam)
+        {
+            Uri slippyMapUrl = new Uri(url);
+            int zoomLevel;
+            double lat;
+            double lng;
+            if (!string.IsNullOrEmpty(slippyMapUrl.Fragment))
+            {
+                // map=18/50.07499/10.21574
+                var pattern = @"map=(\d+)/([-\.\d]+)/([-\.\d]+)";
+                Match match = Regex.Match (slippyMapUrl.Fragment, pattern);
+
+                if (match.Success)
+                {
+                    try
+                    {
+                        zoomLevel = short.Parse (zoomLevelParam, CultureInfo.InvariantCulture);
+                        lat = double.Parse (latParam, CultureInfo.InvariantCulture);
+                        lng = short.Parse (lngParam, CultureInfo.InvariantCulture);
+                    }
+                    catch (FormatException fex)
+                    {
+                        throw new ArgumentException ("Invalid slippymap URL.", fex);
+                    }
+
+                    bounds.Add (CalculateBounds(lat, lng, zoomLevel));
+                }
+                else
+                {
+                    throw new ArgumentException ("Invalid slippymap URL.");
+                }
+            }
+            else if (!string.IsNullOrEmpty(slippyMapUrl.Query))
+            {
+                var queryPart = slippyMapUrl.Query;
+                var queryParameters = HttpUtility.ParseQueryString (queryPart);
+
+                if (queryParameters["lat"] != null && queryParameters["lon"] != null && queryParameters["zoom"] != null)
+                {
+                    try
+                    {
+                        lat = double.Parse (queryParameters["lat"], CultureInfo.InvariantCulture);
+                        lng = double.Parse (queryParameters["lon"], CultureInfo.InvariantCulture);
+                        zoomLevel = short.Parse (queryParameters["zoom"], CultureInfo.InvariantCulture);
+                    }
+                    catch (FormatException fex)
+                    {
+                        throw new ArgumentException("Invalid slippymap URL.", fex);
+                    }
+
+                    bounds.Add (CalculateBounds(lat, lng, zoomLevel));
+                }
+                else if (queryParameters["bbox"] != null)
+                {
+                    bounds.Add (CalculateBounds(queryParameters["bbox"]));
+                }
+                else
+                {
+                    throw new ArgumentException("Invalid slippymap URL.");
+                }
+            }
+            else
+            {
+                throw new ArgumentException("Invalid slippymap URL.");
+            }
+        }
+
         #endregion
 
-        static private List<Bounds2> RetrieveBoundsFromFile(string file)
+        static private List<Bounds2> RetrieveBoundsFromFile (string file)
         {
             if (!File.Exists (file))
                 throw new FileNotFoundException ("File not found.", file);
 
-            List<Bounds2> result = new List<Bounds2> ();
+            var result = new List<Bounds2> ();
 
-            XmlReader reader = XmlReader.Create (file);
+            var reader = XmlReader.Create (file);
             while(reader.ReadToFollowing ("bounds"))
             {
                 string minlat = reader.GetAttribute ("minlat");
@@ -484,7 +519,7 @@ namespace Srtm2Osm
                 string maxlat = reader.GetAttribute ("maxlat");
                 string maxlon = reader.GetAttribute ("maxlon");
 
-                Bounds2 bound = new Bounds2 ();
+                var bound = new Bounds2 ();
 
                 try
                 {
@@ -542,10 +577,10 @@ namespace Srtm2Osm
 
         static private Bounds2 CalculateBounds (string bbox)
         {
-            if (String.IsNullOrEmpty(bbox))
+            if (string.IsNullOrEmpty(bbox))
                 throw new ArgumentException ("String is NULL or empty.", "bbox");
 
-            string[] parts = bbox.Split (new char[] { ',' });
+            var parts = bbox.Split (new char[] { ',' });
 
             if (parts.Length != 4)
                 throw new ArgumentException ("Bounding box has not exactly four parts.", "bbox");
@@ -554,10 +589,10 @@ namespace Srtm2Osm
 
             try
             {
-                minLng = Double.Parse (parts[0], CultureInfo.InvariantCulture);
-                minLat = Double.Parse (parts[1], CultureInfo.InvariantCulture);
-                maxLng = Double.Parse (parts[2], CultureInfo.InvariantCulture);
-                maxLat = Double.Parse (parts[3], CultureInfo.InvariantCulture);
+                minLng = double.Parse (parts[0], CultureInfo.InvariantCulture);
+                minLat = double.Parse (parts[1], CultureInfo.InvariantCulture);
+                maxLng = double.Parse (parts[2], CultureInfo.InvariantCulture);
+                maxLat = double.Parse (parts[3], CultureInfo.InvariantCulture);
             }
             catch (FormatException fex)
             {
@@ -571,12 +606,12 @@ namespace Srtm2Osm
 
         private long GetNextId (IdCounter counter, bool isNodeCounter)
         {
-            bool valid = false;
+            var valid = false;
             long result = counter.GetNextId (out valid);
 
             if (!valid)
             {
-                string msg = String.Format (CultureInfo.InvariantCulture,
+                var msg = string.Format (CultureInfo.InvariantCulture,
                     "Ran out of available ID numbers. {0}crement 'first{1}id' parameter.",
                     incrementId ? "De" : "In", isNodeCounter ? "node" : "way");
                 throw new ArgumentException (msg);
@@ -605,7 +640,9 @@ namespace Srtm2Osm
         private double majorFactor, mediumFactor;
         private IContourMarker contourMarker = new DefaultContourMarker();
         private bool largeAreaMode;
-        private Uri srtmSource;
+        private Uri srtmSource = new Uri("http://firmware.ardupilot.org/SRTM/");
+        private bool srtmSourceFlat;
+        private string srtmSourceExtension = ".hgt.zip";
         private double ? setMinElevation = null;
         private int maxWayNodes = 5000;
         private long firstNodeId = long.MaxValue - 10;


### PR DESCRIPTION
This is a solution for issue #15. The new parameter `-sourceflat` allows the use of unstructured (flat) sources for remote and local location.
With the parameter `-sourceextension` the source archive files are not restricted to `.hgt.zip` anymore. You can use `.zip` instead. Or use `.SRTMGL1.hgt.zip` for the nasa SRTM-1 files (not yet supported).

### Details
- Add option to support unstructured sources (-sourceflat)
- Add option to use specific source file extension (-sourceextension, default: .hgt.zip)
- Redesign index file to support flat sources and avoid _serialization_ of SrtmIndex class (insecure BinaryFormatter will break update to .net 8)
- Suppress error for index recreation with parameter -i without bounds specified
- Cleanup Code of Srtm2OsmCommand
  - extract methods to set source and bounds
  - adjust data types (Double => double, Int16 => short)



Fixes #15
